### PR TITLE
Pick a worker based on response time and queue size

### DIFF
--- a/lib/pigeon/dispatcher_worker.ex
+++ b/lib/pigeon/dispatcher_worker.ex
@@ -49,8 +49,10 @@ defmodule Pigeon.DispatcherWorker do
           |> Map.put(:timing_data, TimingData.new(opts))
           |> Map.put(:on_timeout, opts[:on_timeout])
           |> Map.put(:supervisor, opts[:supervisor])
+          |> Map.put(:adapter, opts[:adapter])
+          |> Map.put(:penalty_box, false)
 
-        {:ok, %{adapter: opts[:adapter], state: state}}
+        {:ok, state}
 
       {:error, reason} ->
         {:error, reason}
@@ -61,28 +63,26 @@ defmodule Pigeon.DispatcherWorker do
   end
 
   @impl GenServer
-  def handle_info({:"$push", notification}, %{adapter: adapter, state: state}) do
-    case adapter.handle_push(notification, state) do
-      {:noreply, new_state} ->
-        {:noreply, %{adapter: adapter, state: new_state}}
-
-      {:stop, reason, new_state} ->
-        {:stop, reason, %{adapter: adapter, state: new_state}}
+  def handle_info({:"$push", notification}, state) do
+    case state.adapter.handle_push(notification, state) do
+      {:noreply, new_state} -> {:noreply, new_state}
+      {:stop, reason, new_state} -> {:stop, reason, new_state}
     end
   end
 
-  def handle_info(msg, %{adapter: adapter, state: state}) do
-    case adapter.handle_info(msg, state) do
-      {:noreply, new_state} ->
-        {:noreply, %{adapter: adapter, state: new_state}}
+  def handle_info({:set_penalty_box, value, duration_ms}, state) do
+    {:noreply, set_penalty_box(state, value, duration_ms)}
+  end
 
-      {:stop, reason, new_state} ->
-        {:stop, reason, %{adapter: adapter, state: new_state}}
+  def handle_info(msg, state) do
+    case state.adapter.handle_info(msg, state) do
+      {:noreply, new_state} -> {:noreply, new_state}
+      {:stop, reason, new_state} -> {:stop, reason, new_state}
     end
   end
 
   @impl GenServer
-  def handle_call(:info, _from, %{adapter: adapter, state: state}) do
+  def handle_call(:info, _from, state) do
     average_response_time_ms =
       System.convert_time_unit(
         state.timing_data.average_native,
@@ -95,14 +95,11 @@ defmodule Pigeon.DispatcherWorker do
       average_response_time_ms: average_response_time_ms
     }
 
-    {:reply, info, %{adapter: adapter, state: state}}
+    {:reply, info, state}
   end
 
   @impl GenServer
-  def handle_cast({:update_timing_data, response_time_native}, %{
-        adapter: adapter,
-        state: state
-      }) do
+  def handle_cast({:update_timing_data, response_time_native}, state) do
     state =
       Map.update!(
         state,
@@ -110,17 +107,21 @@ defmodule Pigeon.DispatcherWorker do
         &TimingData.update(&1, response_time_native)
       )
 
-    set_priority(state.supervisor, state.timing_data.average_native)
-
-    {:noreply, %{adapter: adapter, state: state}}
+    update_priority(state)
+    {:noreply, state}
   end
 
   @impl GenServer
-  def handle_cast(:handle_timeout, s) do
-    if s.state[:on_timeout] == :stop do
-      {:stop, :timeout, s}
-    else
-      {:noreply, s}
+  def handle_cast(:handle_timeout, state) do
+    case state[:on_timeout] do
+      :stop ->
+        {:stop, :timeout, state}
+
+      {:penalty_box, duration_ms} ->
+        {:noreply, set_penalty_box(state, true, duration_ms)}
+
+      _ ->
+        {:noreply, state}
     end
   end
 
@@ -137,10 +138,28 @@ defmodule Pigeon.DispatcherWorker do
     end
   end
 
-  defp set_priority(supervisor, avg_response_time) do
+  defp set_penalty_box(state, true, duration_ms) do
+    Process.send_after(self(), {:set_penalty_box, false, nil}, duration_ms)
+    state = %{state | penalty_box: true}
+    update_priority(state)
+  end
+
+  defp set_penalty_box(state, false, _) do
+    state = %{state | penalty_box: false}
+    update_priority(state)
+  end
+
+  defp update_priority(state = %{penalty_box: true}) do
+    Pigeon.Registry.unregister(state.supervisor)
+    Pigeon.Registry.register(state.supervisor, :infinity)
+    state
+  end
+
+  defp update_priority(state) do
     mailbox_size = Process.info(self())[:message_queue_len]
-    p = avg_response_time * mailbox_size
-    Pigeon.Registry.unregister(supervisor)
-    Pigeon.Registry.register(supervisor, p)
+    p = state.timing_data.average_native * mailbox_size
+    Pigeon.Registry.unregister(state.supervisor)
+    Pigeon.Registry.register(state.supervisor, p)
+    state
   end
 end

--- a/lib/pigeon/registry.ex
+++ b/lib/pigeon/registry.ex
@@ -9,8 +9,8 @@ defmodule Pigeon.Registry do
     }
   end
 
-  def register(pid) do
-    Registry.register(__MODULE__, pid, nil)
+  def register(pid, priority \\ 0) do
+    Registry.register(__MODULE__, pid, priority)
   end
 
   def unregister(pid) do
@@ -20,9 +20,7 @@ defmodule Pigeon.Registry do
   def next(pid) do
     __MODULE__
     |> Registry.lookup(pid)
-    |> case do
-      [] -> nil
-      pids -> pids |> Enum.random() |> elem(0)
-    end
+    |> Enum.min_by(fn {_, priority} -> priority end, fn -> {nil, 0} end)
+    |> elem(0)
   end
 end

--- a/test/pigeon/dispatcher_worker_test.exs
+++ b/test/pigeon/dispatcher_worker_test.exs
@@ -1,0 +1,191 @@
+defmodule Pigeon.DispatcherWorkerTest do
+  use ExUnit.Case
+
+  alias Pigeon.DispatcherWorker
+
+  defmodule ProbeAdapter do
+    @default_state %{last_message: nil, all_messages: [], response_queue: []}
+
+    def init(_opts), do: {:ok, @default_state}
+
+    def handle_push(notification, state) do
+      [response | rest_responses] = get_response_queue(state)
+
+      state =
+        %{
+          state
+          | last_message: notification,
+            all_messages: state.all_messages ++ [notification],
+            response_queue: rest_responses
+        }
+
+      case response do
+        :noreply -> {:noreply, state}
+        {:stop, reason} -> {:stop, reason, state}
+      end
+    end
+
+    def handle_info({:probe, f}, state),
+      do: {:noreply, apply(__MODULE__, f, [state])}
+
+    def handle_info({:probe, f, a}, state),
+      do: {:noreply, apply(__MODULE__, f, a ++ [state])}
+
+    def set_next_response(response, state) do
+      %{state | response_queue: [response]}
+    end
+
+    def set_response_queue(responses, state) do
+      %{state | response_queue: responses}
+    end
+
+    def last_message(to, state), do: send(to, state.last_message)
+    def all_messages(to, state), do: send(to, state.all_messages)
+    def clear(state), do: Map.merge(state, @default_state)
+
+    defp get_response_queue(%{response_queue: []}), do: [:noreply]
+    defp get_response_queue(%{response_queue: queue}), do: queue
+  end
+
+  describe "startup" do
+    test "Throws if adapter not specified" do
+      assert_raise RuntimeError, fn ->
+        DispatcherWorker.start_link([])
+      end
+    end
+
+    test "Starts the GenServer" do
+      {:ok, pid} = DispatcherWorker.start_link(adapter: ProbeAdapter)
+      assert is_pid(pid)
+    end
+
+    test "Registers itself" do
+      {:ok, pid} =
+        DispatcherWorker.start_link(adapter: ProbeAdapter, supervisor: self())
+
+      assert Registry.lookup(Pigeon.Registry, self()) == [{pid, 0}]
+    end
+  end
+
+  describe "push" do
+    setup [:create_worker, :clear_probe]
+
+    test "Sends push to the adapter", ctx do
+      send(ctx.worker, {:"$push", "msg"})
+      send(ctx.worker, {:probe, :last_message, [self()]})
+      assert_receive "msg"
+    end
+
+    test "stops if the adapter tells it to", ctx do
+      Process.flag(:trap_exit, true)
+      send(ctx.worker, {:probe, :set_next_response, [{:stop, :oh_noes}]})
+      send(ctx.worker, {:"$push", "msg"})
+      assert_receive {:EXIT, _, :oh_noes}
+      Process.flag(:trap_exit, false)
+    end
+  end
+
+  describe "timing data" do
+    setup [:create_worker]
+
+    test "retries default timing data", ctx do
+      info = GenServer.call(ctx.worker, :info)
+      assert %{average_response_time_ms: 100} = info
+    end
+
+    test "updates timing data", ctx do
+      t = System.convert_time_unit(200, :millisecond, :native)
+      GenServer.cast(ctx.worker, {:update_timing_data, t})
+      info = GenServer.call(ctx.worker, :info)
+      assert %{average_response_time_ms: 120} = info
+    end
+
+    test "allows you to configure the initial time and alpha values", _ctx do
+      {:ok, worker} =
+        DispatcherWorker.start_link(
+          adapter: ProbeAdapter,
+          initial_average_ms: 500,
+          alpha: 0.5
+        )
+
+      info = GenServer.call(worker, :info)
+      assert %{average_response_time_ms: 500} = info
+
+      t = System.convert_time_unit(1000, :millisecond, :native)
+      GenServer.cast(worker, {:update_timing_data, t})
+      info = GenServer.call(worker, :info)
+      assert %{average_response_time_ms: 750} = info
+    end
+
+    test "updates the priority with the registry", ctx do
+      t = System.convert_time_unit(200, :millisecond, :native)
+      GenServer.cast(ctx.worker, {:update_timing_data, t})
+      _ = GenServer.call(ctx.worker, :info)
+      p = System.convert_time_unit(120, :millisecond, :native)
+      assert Registry.lookup(Pigeon.Registry, self()) == [{ctx.worker, p}]
+    end
+  end
+
+  describe "timeouts" do
+    test "does nothing by default", _ctx do
+      {:ok, worker} =
+        DispatcherWorker.start_link(adapter: ProbeAdapter, supervisor: self())
+
+      GenServer.cast(worker, :handle_timeout)
+      _ = GenServer.call(worker, :info)
+      assert Registry.lookup(Pigeon.Registry, self()) == [{worker, 0}]
+    end
+
+    test "stops if requested", _ctx do
+      {:ok, worker} =
+        DispatcherWorker.start_link(
+          adapter: ProbeAdapter,
+          supervisor: self(),
+          on_timeout: :stop
+        )
+
+      Process.flag(:trap_exit, true)
+      GenServer.cast(worker, :handle_timeout)
+      assert_receive {:EXIT, _, :timeout}
+      Process.flag(:trap_exit, false)
+    end
+
+    test "Puts itself in the penalty box", _ctx do
+      {:ok, worker} =
+        DispatcherWorker.start_link(
+          adapter: ProbeAdapter,
+          supervisor: self(),
+          on_timeout: {:penalty_box, 100}
+        )
+
+      GenServer.cast(worker, :handle_timeout)
+      _ = GenServer.call(worker, :info)
+      worker_list = Registry.lookup(Pigeon.Registry, self())
+      assert worker_list == [{worker, :infinity}]
+      Process.sleep(110)
+      worker_list = Registry.lookup(Pigeon.Registry, self())
+      assert worker_list == [{worker, 0}]
+    end
+  end
+
+  describe "peername" do
+    setup [:create_worker]
+
+    test "returns unknown if no socket", ctx do
+      info = GenServer.call(ctx.worker, :info)
+      assert %{peername: "unknown"} = info
+    end
+  end
+
+  defp create_worker(_ctx) do
+    {:ok, pid} =
+      DispatcherWorker.start_link(adapter: ProbeAdapter, supervisor: self())
+
+    {:ok, worker: pid}
+  end
+
+  defp clear_probe(ctx) do
+    send(ctx.worker, {:probe, :clear})
+    :ok
+  end
+end


### PR DESCRIPTION
Also some refactoring and some tests added.

Most of the testbench doesn't run without setting a bunch of tokens and stuff, but my tests for this didn't depend on any of that, so I just commented out all of the workers in `test_helpers.exs` and ran my one test module. It passes.