### PR TITLE
WIP: enforce unique connections

### DIFF
--- a/lib/pigeon/apns.ex
+++ b/lib/pigeon/apns.ex
@@ -211,7 +211,9 @@ defmodule Pigeon.APNS do
     {:noreply, state}
   end
 
-  def handle_info({:closed, _}, %{config: config} = state) do
+  def handle_info({:closed, pid}, %{config: config} = state) do
+    Pigeon.SocketTracker.release(pid)
+
     case connect_socket(config) do
       {:ok, socket} ->
         Configurable.schedule_ping(config)

--- a/lib/pigeon/application.ex
+++ b/lib/pigeon/application.ex
@@ -5,6 +5,9 @@ defmodule Pigeon.Application do
   alias Pigeon.APNS
   alias Pigeon.Http2.Client
 
+  @ets_peer_table :ets_peer_table
+  def ets_peer_table, do: @ets_peer_table
+
   @doc false
   def start(_type, _args) do
     Client.default().start
@@ -14,6 +17,8 @@ defmodule Pigeon.Application do
       {APNS.Token, %{}},
       {Task.Supervisor, name: Pigeon.Tasks}
     ]
+
+    :ets.new(@ets_peer_table, [:set, :public, :named_table])
 
     opts = [strategy: :one_for_one, name: :pigeon]
     Supervisor.start_link(children, opts)

--- a/lib/pigeon/configurable.ex
+++ b/lib/pigeon/configurable.ex
@@ -3,7 +3,7 @@ defprotocol Pigeon.Configurable do
 
   @type sock :: {:sslsocket, any, pid | {any, any}}
 
-  @spec connect(any) :: {:ok, sock} | {:error, String.t()}
+  @spec connect(any) :: {:ok, sock} | {:error, String.t() | atom()}
   def connect(config)
 
   def push_headers(config, notification, opts)

--- a/lib/pigeon/dispatcher_worker.ex
+++ b/lib/pigeon/dispatcher_worker.ex
@@ -127,12 +127,8 @@ defmodule Pigeon.DispatcherWorker do
 
   defp peername(state) do
     with %{socket: socket} <- state,
-         %{connection: connection} <- :sys.get_state(socket),
-         %{config: %{socket: socket2}} <- :sys.get_state(connection),
-         %{socket: socket3} <- :sys.get_state(socket2),
-         {_, {_, port, _, _}, _} <- socket3,
-         {:ok, addr} <- :inet.peername(port) do
-      addr
+         {:ok, peername} <- Pigeon.Shared.peername(socket) do
+      peername
     else
       _ -> "unknown"
     end

--- a/lib/pigeon/fcm.ex
+++ b/lib/pigeon/fcm.ex
@@ -96,7 +96,8 @@ defmodule Pigeon.FCM do
             retries: @max_retries,
             socket: nil,
             stream_id: 1,
-            token: nil
+            token: nil,
+            allow_duplicate_connections: true
 
   @behaviour Pigeon.Adapter
 
@@ -199,7 +200,11 @@ defmodule Pigeon.FCM do
   defp connect_socket(config, tries) do
     case Configurable.connect(config) do
       {:ok, socket} ->
+        IO.puts("***** FCM ok")
         {:ok, socket}
+
+      {:error, :duplicate} ->
+        connect_socket(config, tries)
 
       {:error, reason} ->
         if tries > 0 do

--- a/lib/pigeon/fcm/config.ex
+++ b/lib/pigeon/fcm/config.ex
@@ -92,7 +92,7 @@ defimpl Pigeon.Configurable, for: Pigeon.FCM.Config do
   def connect(%Config{uri: uri} = config) do
     case connect_socket_options(config) do
       {:ok, options} ->
-        Pigeon.Http2.Client.default().connect(uri |> dbg, :https, options)
+        Pigeon.Http2.Client.default().connect(uri, :https, options)
         |> Pigeon.SocketTracker.check_duplicate(
           config.allow_duplicate_connections
         )

--- a/lib/pigeon/http2/kadabra.ex
+++ b/lib/pigeon/http2/kadabra.ex
@@ -12,6 +12,10 @@ defmodule Pigeon.Http2.Client.Kadabra do
     Kadabra.open(host, ssl: opts)
   end
 
+  def close(pid) do
+    Kadabra.close(pid)
+  end
+
   def send_request(pid, headers, data) do
     Kadabra.request(pid, headers: headers, body: data)
   end

--- a/lib/pigeon/shared.ex
+++ b/lib/pigeon/shared.ex
@@ -1,0 +1,14 @@
+defmodule Pigeon.Shared do
+  @moduledoc false
+
+  def peername(socket) do
+    with %{connection: connection} <- :sys.get_state(socket),
+         %{config: %{socket: socket2}} <- :sys.get_state(connection),
+         %{socket: socket3} <- :sys.get_state(socket2),
+         {_, {_, port, _, _}, _} <- socket3 do
+      :inet.peername(port)
+    else
+      _ -> {:error, :unknown}
+    end
+  end
+end

--- a/lib/pigeon/socket_tracker.ex
+++ b/lib/pigeon/socket_tracker.ex
@@ -1,0 +1,39 @@
+defmodule Pigeon.SocketTracker do
+  @moduledoc false
+  require Logger
+
+  @ets_peer_table Pigeon.Application.ets_peer_table()
+
+  @doc """
+  Check in the ETS table if the given socket (according to its peername) is a duplicate. If
+  it is and if `allow_duplicates` is false, then the socket is added to the table and
+  `{:error, :duplicate}` is returned. Otherwise the connect response is returned as-is.
+  """
+  @spec check_duplicate(term(), boolean()) ::
+          {:ok, any()} | {:error, :duplicate} | any()
+  def check_duplicate(connect_response, allow_duplicates)
+
+  def check_duplicate({:ok, socket}, false) do
+    with {:ok, peername} <- Pigeon.Shared.peername(socket),
+         dbg(peername),
+         true <- :ets.insert_new(@ets_peer_table, {peername}) do
+      IO.puts("***** unique")
+      {:ok, socket}
+    else
+      false ->
+        IO.puts("***** duplicate")
+        Process.unlink(socket)
+        Pigeon.Http2.Client.default().close(socket)
+        {:error, :duplicate}
+
+      error ->
+        Logger.warning(
+          "Couldn't get peername for socket. Duplicate check skipped. #{inspect(error)}"
+        )
+
+        {:ok, socket}
+    end
+  end
+
+  def check_duplicate(s, _), do: s
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,12 +1,12 @@
 ExUnit.start(capture_log: true)
 
 workers = [
-  PigeonTest.ADM,
-  PigeonTest.APNS,
-  PigeonTest.APNS.JWT,
-  PigeonTest.FCM,
-  PigeonTest.LegacyFCM,
-  PigeonTest.Sandbox
+  # PigeonTest.ADM,
+  # PigeonTest.APNS,
+  # PigeonTest.APNS.JWT,
+  # PigeonTest.FCM,
+  # PigeonTest.LegacyFCM,
+  # PigeonTest.Sandbox
 ]
 
 Supervisor.start_link(workers, strategy: :one_for_one)


### PR DESCRIPTION
This PR attempts (unsuccessfully) to implement a system where whenever a socket connects to a remote endpoint, it (optionally) checks in an ETS table to determine whether we already have a connection to that endpoint. If so, it drops that connection and tries again.

I got it working for initial startup: it will do it's best to get a unique connection for every worker in the pool for each dispatcher. It takes quite a bit of time at startup though to randomly land on 8 (APNs) + 8 (APNs Sandbox) + 4 (FCM) unique connections.

Also, I couldn't get reconnects to work successfully. When we get the `{:closed, pid}` message, the `pid` doesn't seem to exist any more so we can't dig into it to discover the remote peername. Because of this, we can't remove the associated entry from the ETS table, so we would end up slowly exhausting all the remote servers, never able to reuse the same one.