### PR TITLE
Go back to random worker routing

### DIFF
--- a/lib/pigeon/registry.ex
+++ b/lib/pigeon/registry.ex
@@ -20,7 +20,9 @@ defmodule Pigeon.Registry do
   def next(pid) do
     __MODULE__
     |> Registry.lookup(pid)
-    |> Enum.min_by(fn {_, priority} -> priority end, fn -> {nil, 0} end)
-    |> elem(0)
+    |> case do
+      [] -> nil
+      pids -> pids |> Enum.random() |> elem(0)
+    end
   end
 end


### PR DESCRIPTION
#9 added some heuristic logic to choosing which worker would service the next request. That seemed to lead to more timeouts in practice, so reverting to the randomized strategy for now.